### PR TITLE
fix: default value of globals option to align with conditional logic

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -22,7 +22,7 @@ if (options.verbose) {
 const {
   cwd = process.cwd(),
   verbose = false,
-  checkUnknownGlobals: globals = undefined,
+  checkUnknownGlobals: globals = null,
 } = options;
 
 try {

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,7 +22,7 @@ if (options.verbose) {
 const {
   cwd = process.cwd(),
   verbose = false,
-  checkUnknownGlobals: globals = null,
+  globals = null,
 } = options;
 
 try {


### PR DESCRIPTION
Fix a bug where the globals check would always be run by default without the user specifying the `-g` / `--globals` option due to a misalignment between the default value and the check.

e.g. the `main.js` expects the globals option to be `null`, and the `cli.js` uses `undefined` as the default value.

In addition, the reference to the `globals` cli option was also broken as it was referencing to the incorrect property name (introduced in a9c8df65f6925c446ae3cb61ce8b68d39655244b).